### PR TITLE
Make gqf much more friendly to use as a library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-*
 !.gitignore
 !.*.sh
 

--- a/include/gqf.h
+++ b/include/gqf.h
@@ -26,13 +26,13 @@
 extern "C" {
 #endif
 
-	enum hashmode {
+	enum qf_hashmode {
 		DEFAULT,
 		INVERTIBLE,
 		NONE
 	};
 
-	enum lockingmode {
+	enum qf_lockingmode {
 		LOCKS_FORBIDDEN,
 		LOCKS_OPTIONAL,
 		LOCKS_REQUIRED
@@ -52,18 +52,18 @@ extern "C" {
 	 * needed in bytes to initialize the CQF.
 	 * */
 	uint64_t qf_init(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t
-									 value_bits, enum lockingmode lock, enum hashmode hash,
+									 value_bits, enum qf_lockingmode lock, enum qf_hashmode hash,
 									 uint32_t seed, void* buffer, uint64_t buffer_len);
 
 	/* Read the CQF stored at "buffer". */
-	uint64_t qf_use(QF* qf, void* buffer, uint64_t buffer_len, enum lockingmode
+	uint64_t qf_use(QF* qf, void* buffer, uint64_t buffer_len, enum qf_lockingmode
 									lock);
 
 	void *qf_destroy(QF *qf);
 
 	/* Initialize the CQF and allocate memory for the CQF. */
 	bool qf_malloc(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t
-								 value_bits, enum lockingmode lock, enum hashmode hash,
+								 value_bits, enum qf_lockingmode lock, enum qf_hashmode hash,
 								 uint32_t seed);
 
 	bool qf_free(QF *qf);

--- a/include/gqf.h
+++ b/include/gqf.h
@@ -26,44 +26,6 @@
 extern "C" {
 #endif
 
-/* Can be 
-   0 (choose size at run-time), 
-   8, 16, 32, or 64 (for optimized versions),
-   or other integer <= 56 (for compile-time-optimized bit-shifting-based versions)
-*/
-#define QF_BITS_PER_SLOT 0
-
-/* Must be >= 6.  6 seems fastest. */
-#define QF_BLOCK_OFFSET_BITS (6)
-
-#define QF_SLOTS_PER_BLOCK (1ULL << QF_BLOCK_OFFSET_BITS)
-#define QF_METADATA_WORDS_PER_BLOCK ((QF_SLOTS_PER_BLOCK + 63) / 64)
-
-	typedef struct __attribute__ ((__packed__)) qfblock {
-		/* Code works with uint16_t, uint32_t, etc, but uint8_t seems just as fast as
-		 * anything else */
-		uint8_t offset; 
-		uint64_t occupieds[QF_METADATA_WORDS_PER_BLOCK];
-		uint64_t runends[QF_METADATA_WORDS_PER_BLOCK];
-
-#if QF_BITS_PER_SLOT == 8
-		uint8_t  slots[QF_SLOTS_PER_BLOCK];
-#elif QF_BITS_PER_SLOT == 16
-		uint16_t  slots[QF_SLOTS_PER_BLOCK];
-#elif QF_BITS_PER_SLOT == 32
-		uint32_t  slots[QF_SLOTS_PER_BLOCK];
-#elif QF_BITS_PER_SLOT == 64
-		uint64_t  slots[QF_SLOTS_PER_BLOCK];
-#elif QF_BITS_PER_SLOT != 0
-		uint8_t   slots[QF_SLOTS_PER_BLOCK * QF_BITS_PER_SLOT / 8];
-#else
-		uint8_t   slots[];
-#endif
-	} qfblock;
-
-	struct __attribute__ ((__packed__)) qfblock;
-	typedef struct qfblock qfblock;
-
 	enum hashmode {
 		DEFAULT,
 		INVERTIBLE,
@@ -76,76 +38,10 @@ extern "C" {
 		LOCKS_REQUIRED
 	};
 
-  typedef struct file_info {
-		int fd;
-		char *filepath;
-	} file_info;
-
-	// The below struct is used to instrument the code.
-	// It is not used in normal operations of the CQF.
-	typedef struct {
-		uint64_t total_time_single;
-		uint64_t total_time_spinning;
-		uint64_t locks_taken;
-		uint64_t locks_acquired_single_attempt;
-	} wait_time_data;
-
-	typedef struct quotient_filter_runtime_data {
-		file_info f_info;
-		uint64_t num_locks;
-		enum lockingmode lock_mode;
-		volatile int metadata_lock;
-		volatile int *locks;
-		wait_time_data *wait_times;
-	} quotient_filter_runtime_data;
-
-	typedef quotient_filter_runtime_data qfruntime;
-
-	typedef struct quotient_filter_metadata {
-		enum hashmode hash_mode;
-		uint32_t auto_resize;
-		uint64_t total_size_in_bytes;
-		uint32_t seed;
-		uint64_t nslots;
-		uint64_t xnslots;
-		uint64_t key_bits;
-		uint64_t value_bits;
-		uint64_t key_remainder_bits;
-		uint64_t bits_per_slot;
-		__uint128_t range;
-		uint64_t nblocks;
-		uint64_t nelts;
-		uint64_t ndistinct_elts;
-		uint64_t noccupied_slots;
-	} quotient_filter_metadata;
-
-	typedef quotient_filter_metadata qfmetadata;
-
-	typedef struct quotient_filter {
-		qfruntime *runtimedata;
-		qfmetadata *metadata;
-		qfblock *blocks;
-	} quotient_filter;
-
+	typedef struct quotient_filter_s quotient_filter;
 	typedef quotient_filter QF;
 
-	// The below struct is used to instrument the code.
-	// It is not used in normal operations of the CQF.
-	typedef struct {
-		uint64_t start_index;
-		uint16_t length;
-	} cluster_data;
-
-	typedef struct quotient_filter_iterator {
-		const QF *qf;
-		uint64_t run;
-		uint64_t current;
-		uint64_t cur_start_index;
-		uint16_t cur_length;
-		uint32_t num_clusters;
-		cluster_data *c_info;
-	} quotient_filter_iterator;
-
+  typedef struct quotient_filter_iterator_s quotient_filter_iterator;
 	typedef quotient_filter_iterator QFi;
 
 	/* Forward declaration for the macro. */

--- a/include/gqf.h
+++ b/include/gqf.h
@@ -20,7 +20,6 @@
 #define _GQF_H_
 
 #include <inttypes.h>
-#include <pthread.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -89,7 +88,7 @@ extern "C" {
 		LOCKS_REQUIRED
 	};
 
-	typedef struct file_info {
+  typedef struct file_info {
 		int fd;
 		char *filepath;
 	} file_info;

--- a/include/gqf.h
+++ b/include/gqf.h
@@ -33,23 +33,11 @@ extern "C" {
 		 */
 #define BITS_PER_SLOT 0
 
-#define BITMASK(nbits) ((nbits) == 64 ? 0xffffffffffffffff : (1ULL << (nbits)) \
-												- 1ULL)
-
 	/* Must be >= 6.  6 seems fastest. */
 #define BLOCK_OFFSET_BITS (6)
 
 #define SLOTS_PER_BLOCK (1ULL << BLOCK_OFFSET_BITS)
 #define METADATA_WORDS_PER_BLOCK ((SLOTS_PER_BLOCK + 63) / 64)
-
-#define NUM_SLOTS_TO_LOCK (1ULL<<16)
-#define CLUSTER_SIZE (1ULL<<14)
-
-#define METADATA_WORD(qf,field,slot_index) (get_block((qf), (slot_index) / \
-																											SLOTS_PER_BLOCK)->field[((slot_index)  % SLOTS_PER_BLOCK) / 64])
-
-#define MAX_VALUE(nbits) ((1ULL << (nbits)) - 1)
-#define BILLION 1000000000L
 
 	typedef struct __attribute__ ((__packed__)) qfblock {
 		/* Code works with uint16_t, uint32_t, etc, but uint8_t seems just as fast as
@@ -162,12 +150,6 @@ extern "C" {
 
 	/* Forward declaration for the macro. */
 	void qf_dump_metadata(const QF *qf);
-
-#define DEBUG_CQF(fmt, ...) \
-	do { if (PRINT_DEBUG) fprintf(stderr, fmt, __VA_ARGS__); } while (0)
-
-#define DEBUG_DUMP(qf) \
-	do { if (PRINT_DEBUG) qf_dump_metadata(qf); } while (0)
 
 	/* Initialize the CQF at "buffer".
 	 * If there is not enough space at buffer then it will return the total size

--- a/include/gqf.h
+++ b/include/gqf.h
@@ -26,36 +26,36 @@
 extern "C" {
 #endif
 
-	/* Can be 
-		 0 (choose size at run-time), 
-		 8, 16, 32, or 64 (for optimized versions),
-		 or other integer <= 56 (for compile-time-optimized bit-shifting-based versions)
-		 */
-#define BITS_PER_SLOT 0
+/* Can be 
+   0 (choose size at run-time), 
+   8, 16, 32, or 64 (for optimized versions),
+   or other integer <= 56 (for compile-time-optimized bit-shifting-based versions)
+*/
+#define QF_BITS_PER_SLOT 0
 
-	/* Must be >= 6.  6 seems fastest. */
-#define BLOCK_OFFSET_BITS (6)
+/* Must be >= 6.  6 seems fastest. */
+#define QF_BLOCK_OFFSET_BITS (6)
 
-#define SLOTS_PER_BLOCK (1ULL << BLOCK_OFFSET_BITS)
-#define METADATA_WORDS_PER_BLOCK ((SLOTS_PER_BLOCK + 63) / 64)
+#define QF_SLOTS_PER_BLOCK (1ULL << QF_BLOCK_OFFSET_BITS)
+#define QF_METADATA_WORDS_PER_BLOCK ((QF_SLOTS_PER_BLOCK + 63) / 64)
 
 	typedef struct __attribute__ ((__packed__)) qfblock {
 		/* Code works with uint16_t, uint32_t, etc, but uint8_t seems just as fast as
 		 * anything else */
 		uint8_t offset; 
-		uint64_t occupieds[METADATA_WORDS_PER_BLOCK];
-		uint64_t runends[METADATA_WORDS_PER_BLOCK];
+		uint64_t occupieds[QF_METADATA_WORDS_PER_BLOCK];
+		uint64_t runends[QF_METADATA_WORDS_PER_BLOCK];
 
-#if BITS_PER_SLOT == 8
-		uint8_t  slots[SLOTS_PER_BLOCK];
-#elif BITS_PER_SLOT == 16
-		uint16_t  slots[SLOTS_PER_BLOCK];
-#elif BITS_PER_SLOT == 32
-		uint32_t  slots[SLOTS_PER_BLOCK];
-#elif BITS_PER_SLOT == 64
-		uint64_t  slots[SLOTS_PER_BLOCK];
-#elif BITS_PER_SLOT != 0
-		uint8_t   slots[SLOTS_PER_BLOCK * BITS_PER_SLOT / 8];
+#if QF_BITS_PER_SLOT == 8
+		uint8_t  slots[QF_SLOTS_PER_BLOCK];
+#elif QF_BITS_PER_SLOT == 16
+		uint16_t  slots[QF_SLOTS_PER_BLOCK];
+#elif QF_BITS_PER_SLOT == 32
+		uint32_t  slots[QF_SLOTS_PER_BLOCK];
+#elif QF_BITS_PER_SLOT == 64
+		uint64_t  slots[QF_SLOTS_PER_BLOCK];
+#elif QF_BITS_PER_SLOT != 0
+		uint8_t   slots[QF_SLOTS_PER_BLOCK * QF_BITS_PER_SLOT / 8];
 #else
 		uint8_t   slots[];
 #endif

--- a/include/gqf_file.h
+++ b/include/gqf_file.h
@@ -31,11 +31,11 @@ extern "C" {
 
 	/* Initialize a file-backed CQF at "filename". */
 	bool qf_initfile(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t
-									value_bits, enum lockingmode lock, enum hashmode hash,
+									value_bits, enum qf_lockingmode lock, enum qf_hashmode hash,
 									uint32_t seed, char* filename);
 
 	/* Read "filename" into "qf". */
-	uint64_t qf_usefile(QF* qf, enum lockingmode lock, const char* filename);
+	uint64_t qf_usefile(QF* qf, enum qf_lockingmode lock, const char* filename);
 
 	bool qf_closefile(QF* qf);
 
@@ -45,7 +45,7 @@ extern "C" {
 	uint64_t qf_serialize(const QF *qf, const char *filename);
 
 	/* read data structure off the disk */
-	uint64_t qf_deserialize(QF *qf, enum lockingmode lock, const char *filename);
+	uint64_t qf_deserialize(QF *qf, enum qf_lockingmode lock, const char *filename);
 
 #ifdef __cplusplus
 }

--- a/include/gqf_int.h
+++ b/include/gqf_int.h
@@ -1,0 +1,125 @@
+#ifndef _GQF_INT_H_
+#define _GQF_INT_H_
+
+#include <inttypes.h>
+#include <stdbool.h>
+
+#include "gqf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Can be 
+   0 (choose size at run-time), 
+   8, 16, 32, or 64 (for optimized versions),
+   or other integer <= 56 (for compile-time-optimized bit-shifting-based versions)
+*/
+#define QF_BITS_PER_SLOT 0
+
+/* Must be >= 6.  6 seems fastest. */
+#define QF_BLOCK_OFFSET_BITS (6)
+
+#define QF_SLOTS_PER_BLOCK (1ULL << QF_BLOCK_OFFSET_BITS)
+#define QF_METADATA_WORDS_PER_BLOCK ((QF_SLOTS_PER_BLOCK + 63) / 64)
+
+	typedef struct __attribute__ ((__packed__)) qfblock {
+		/* Code works with uint16_t, uint32_t, etc, but uint8_t seems just as fast as
+		 * anything else */
+		uint8_t offset; 
+		uint64_t occupieds[QF_METADATA_WORDS_PER_BLOCK];
+		uint64_t runends[QF_METADATA_WORDS_PER_BLOCK];
+
+#if QF_BITS_PER_SLOT == 8
+		uint8_t  slots[QF_SLOTS_PER_BLOCK];
+#elif QF_BITS_PER_SLOT == 16
+		uint16_t  slots[QF_SLOTS_PER_BLOCK];
+#elif QF_BITS_PER_SLOT == 32
+		uint32_t  slots[QF_SLOTS_PER_BLOCK];
+#elif QF_BITS_PER_SLOT == 64
+		uint64_t  slots[QF_SLOTS_PER_BLOCK];
+#elif QF_BITS_PER_SLOT != 0
+		uint8_t   slots[QF_SLOTS_PER_BLOCK * QF_BITS_PER_SLOT / 8];
+#else
+		uint8_t   slots[];
+#endif
+	} qfblock;
+
+	struct __attribute__ ((__packed__)) qfblock;
+	typedef struct qfblock qfblock;
+
+  typedef struct file_info {
+		int fd;
+		char *filepath;
+	} file_info;
+
+	// The below struct is used to instrument the code.
+	// It is not used in normal operations of the CQF.
+	typedef struct {
+		uint64_t total_time_single;
+		uint64_t total_time_spinning;
+		uint64_t locks_taken;
+		uint64_t locks_acquired_single_attempt;
+	} wait_time_data;
+
+	typedef struct quotient_filter_runtime_data {
+		file_info f_info;
+		uint64_t num_locks;
+		enum qf_lockingmode lock_mode;
+		volatile int metadata_lock;
+		volatile int *locks;
+		wait_time_data *wait_times;
+	} quotient_filter_runtime_data;
+
+	typedef quotient_filter_runtime_data qfruntime;
+
+	typedef struct quotient_filter_metadata {
+		enum qf_hashmode hash_mode;
+		uint32_t auto_resize;
+		uint64_t total_size_in_bytes;
+		uint32_t seed;
+		uint64_t nslots;
+		uint64_t xnslots;
+		uint64_t key_bits;
+		uint64_t value_bits;
+		uint64_t key_remainder_bits;
+		uint64_t bits_per_slot;
+		__uint128_t range;
+		uint64_t nblocks;
+		uint64_t nelts;
+		uint64_t ndistinct_elts;
+		uint64_t noccupied_slots;
+	} quotient_filter_metadata;
+
+	typedef quotient_filter_metadata qfmetadata;
+
+	typedef struct quotient_filter_s {
+		qfruntime *runtimedata;
+		qfmetadata *metadata;
+		qfblock *blocks;
+	} quotient_filter;
+
+	typedef quotient_filter QF;
+
+	// The below struct is used to instrument the code.
+	// It is not used in normal operations of the CQF.
+	typedef struct {
+		uint64_t start_index;
+		uint16_t length;
+	} cluster_data;
+
+	typedef struct quotient_filter_iterator_s {
+		const QF *qf;
+		uint64_t run;
+		uint64_t current;
+		uint64_t cur_start_index;
+		uint16_t cur_length;
+		uint32_t num_clusters;
+		cluster_data *c_info;
+	} quotient_filter_iterator;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _GQF_INT_H_ */

--- a/src/gqf.c
+++ b/src/gqf.c
@@ -131,7 +131,7 @@ static inline bool qf_spin_lock(QF *qf, volatile int *lock, uint64_t idx)
  * Try to acquire a lock once and return even if the lock is busy.
  * If spin flag is set, then spin until the lock is available.
  */
-static inline bool qf_spin_lock(volatile int *lock, enum lockingmode flag)
+static inline bool qf_spin_lock(volatile int *lock, enum qf_lockingmode flag)
 {
 	if (flag != LOCKS_REQUIRED) {
 		return !__sync_lock_test_and_set(lock, 1);
@@ -1446,7 +1446,7 @@ static inline bool insert1(QF *qf, __uint128_t hash)
 }
 
 static inline bool insert(QF *qf, __uint128_t hash, uint64_t count, enum
-													lockingmode flag)
+													qf_lockingmode flag)
 {
 	uint64_t hash_remainder           = hash & BITMASK(qf->metadata->bits_per_slot);
 	uint64_t hash_bucket_index        = hash >> qf->metadata->bits_per_slot;
@@ -1614,7 +1614,7 @@ inline static bool _remove(QF *qf, __uint128_t hash, uint64_t count)
  ***********************************************************************/
 
 uint64_t qf_init(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t value_bits,
-								 enum lockingmode lock, enum hashmode hash, uint32_t seed,
+								 enum qf_lockingmode lock, enum qf_hashmode hash, uint32_t seed,
 								 void* buffer, uint64_t buffer_len)
 {
 	uint64_t num_slots, xnslots, nblocks;
@@ -1686,7 +1686,7 @@ uint64_t qf_init(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t value_bits
 	return total_num_bytes;
 }
 
-uint64_t qf_use(QF* qf, void* buffer, uint64_t buffer_len, enum lockingmode
+uint64_t qf_use(QF* qf, void* buffer, uint64_t buffer_len, enum qf_lockingmode
 								lock)
 {
 	qf->metadata = (qfmetadata *)(buffer);
@@ -1719,7 +1719,7 @@ void *qf_destroy(QF *qf)
 }
 
 bool qf_malloc(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t
-							 value_bits, enum lockingmode lock, enum hashmode hash, uint32_t
+							 value_bits, enum qf_lockingmode lock, enum qf_hashmode hash, uint32_t
 							 seed)
 {
 	uint64_t total_num_bytes = qf_init(qf, nslots, key_bits, value_bits,

--- a/src/gqf.c
+++ b/src/gqf.c
@@ -35,6 +35,7 @@
 
 #include "hashutil.h"
 #include "gqf.h"
+#include "gqf_int.h"
 
 /******************************************************************
  * Code for managing the metadata bits and slots w/o interpreting *

--- a/src/gqf.c
+++ b/src/gqf.c
@@ -42,13 +42,13 @@
  ******************************************************************/
 
 #define MAX_VALUE(nbits) ((1ULL << (nbits)) - 1)
-#define BITMASK(nbits)                                            \
+#define BITMASK(nbits)                                    \
   ((nbits) == 64 ? 0xffffffffffffffff : MAX_VALUE(nbits))
 #define NUM_SLOTS_TO_LOCK (1ULL<<16)
 #define CLUSTER_SIZE (1ULL<<14)
 #define METADATA_WORD(qf,field,slot_index)                              \
   (get_block((qf), (slot_index) /                                       \
-             SLOTS_PER_BLOCK)->field[((slot_index)  % SLOTS_PER_BLOCK) / 64])
+             QF_SLOTS_PER_BLOCK)->field[((slot_index)  % QF_SLOTS_PER_BLOCK) / 64])
 
 
 #define BILLION 1000000000L
@@ -445,7 +445,7 @@ static inline uint64_t bitselectv(const uint64_t val, int ignore, int rank)
 	return bitselect(val & ~BITMASK(ignore % 64), rank);
 }
 
-#if BITS_PER_SLOT > 0
+#if QF_BITS_PER_SLOT > 0
 static inline qfblock * get_block(const QF *qf, uint64_t block_index)
 {
 	return &qf->blocks[block_index];
@@ -454,38 +454,38 @@ static inline qfblock * get_block(const QF *qf, uint64_t block_index)
 static inline qfblock * get_block(const QF *qf, uint64_t block_index)
 {
 	return (qfblock *)(((char *)qf->blocks) + block_index * (sizeof(qfblock) +
-						SLOTS_PER_BLOCK * qf->metadata->bits_per_slot / 8));
+						QF_SLOTS_PER_BLOCK * qf->metadata->bits_per_slot / 8));
 }
 #endif
 
 static inline int is_runend(const QF *qf, uint64_t index)
 {
-	return (METADATA_WORD(qf, runends, index) >> ((index % SLOTS_PER_BLOCK) %
+	return (METADATA_WORD(qf, runends, index) >> ((index % QF_SLOTS_PER_BLOCK) %
 																								64)) & 1ULL;
 }
 
 static inline int is_occupied(const QF *qf, uint64_t index)
 {
-	return (METADATA_WORD(qf, occupieds, index) >> ((index % SLOTS_PER_BLOCK) %
+	return (METADATA_WORD(qf, occupieds, index) >> ((index % QF_SLOTS_PER_BLOCK) %
 																									64)) & 1ULL;
 }
 
-#if BITS_PER_SLOT == 8 || BITS_PER_SLOT == 16 || BITS_PER_SLOT == 32 || BITS_PER_SLOT == 64
+#if QF_BITS_PER_SLOT == 8 || QF_BITS_PER_SLOT == 16 || QF_BITS_PER_SLOT == 32 || QF_BITS_PER_SLOT == 64
 
 static inline uint64_t get_slot(const QF *qf, uint64_t index)
 {
 	assert(index < qf->metadata->xnslots);
-	return get_block(qf, index / SLOTS_PER_BLOCK)->slots[index % SLOTS_PER_BLOCK];
+	return get_block(qf, index / QF_SLOTS_PER_BLOCK)->slots[index % QF_SLOTS_PER_BLOCK];
 }
 
 static inline void set_slot(const QF *qf, uint64_t index, uint64_t value)
 {
 	assert(index < qf->metadata->xnslots);
-	get_block(qf, index / SLOTS_PER_BLOCK)->slots[index % SLOTS_PER_BLOCK] =
+	get_block(qf, index / QF_SLOTS_PER_BLOCK)->slots[index % QF_SLOTS_PER_BLOCK] =
 		value & BITMASK(qf->metadata->bits_per_slot);
 }
 
-#elif BITS_PER_SLOT > 0
+#elif QF_BITS_PER_SLOT > 0
 
 /* Little-endian code ....  Big-endian is TODO */
 
@@ -495,11 +495,11 @@ static inline uint64_t get_slot(const QF *qf, uint64_t index)
 	 * to generate buggy code.  :/  */
 	assert(index < qf->metadata->xnslots);
 	uint64_t *p = (uint64_t *)&get_block(qf, index /
-																			 SLOTS_PER_BLOCK)->slots[(index %
-																																SLOTS_PER_BLOCK)
-																			 * BITS_PER_SLOT / 8];
-	return (uint64_t)(((*p) >> (((index % SLOTS_PER_BLOCK) * BITS_PER_SLOT) %
-															8)) & BITMASK(BITS_PER_SLOT));
+																			 QF_SLOTS_PER_BLOCK)->slots[(index %
+																																QF_SLOTS_PER_BLOCK)
+																			 * QF_BITS_PER_SLOT / 8];
+	return (uint64_t)(((*p) >> (((index % QF_SLOTS_PER_BLOCK) * QF_BITS_PER_SLOT) %
+															8)) & BITMASK(QF_BITS_PER_SLOT));
 }
 
 static inline void set_slot(const QF *qf, uint64_t index, uint64_t value)
@@ -508,13 +508,13 @@ static inline void set_slot(const QF *qf, uint64_t index, uint64_t value)
 	 * to generate buggy code.  :/  */
 	assert(index < qf->metadata->xnslots);
 	uint64_t *p = (uint64_t *)&get_block(qf, index /
-																			 SLOTS_PER_BLOCK)->slots[(index %
-																																SLOTS_PER_BLOCK)
-																			 * BITS_PER_SLOT / 8];
+																			 QF_SLOTS_PER_BLOCK)->slots[(index %
+																																QF_SLOTS_PER_BLOCK)
+																			 * QF_BITS_PER_SLOT / 8];
 	uint64_t t = *p;
-	uint64_t mask = BITMASK(BITS_PER_SLOT);
+	uint64_t mask = BITMASK(QF_BITS_PER_SLOT);
 	uint64_t v = value;
-	int shift = ((index % SLOTS_PER_BLOCK) * BITS_PER_SLOT) % 8;
+	int shift = ((index % QF_SLOTS_PER_BLOCK) * QF_BITS_PER_SLOT) % 8;
 	mask <<= shift;
 	v <<= shift;
 	t &= ~mask;
@@ -532,10 +532,10 @@ static inline uint64_t get_slot(const QF *qf, uint64_t index)
 	/* Should use __uint128_t to support up to 64-bit remainders, but gcc seems
 	 * to generate buggy code.  :/  */
 	uint64_t *p = (uint64_t *)&get_block(qf, index /
-																			 SLOTS_PER_BLOCK)->slots[(index %
-																																SLOTS_PER_BLOCK)
+																			 QF_SLOTS_PER_BLOCK)->slots[(index %
+																																QF_SLOTS_PER_BLOCK)
 																			 * qf->metadata->bits_per_slot / 8];
-	return (uint64_t)(((*p) >> (((index % SLOTS_PER_BLOCK) *
+	return (uint64_t)(((*p) >> (((index % QF_SLOTS_PER_BLOCK) *
 															 qf->metadata->bits_per_slot) % 8)) &
 										BITMASK(qf->metadata->bits_per_slot));
 }
@@ -546,13 +546,13 @@ static inline void set_slot(const QF *qf, uint64_t index, uint64_t value)
 	/* Should use __uint128_t to support up to 64-bit remainders, but gcc seems
 	 * to generate buggy code.  :/  */
 	uint64_t *p = (uint64_t *)&get_block(qf, index /
-																			 SLOTS_PER_BLOCK)->slots[(index %
-																																SLOTS_PER_BLOCK)
+																			 QF_SLOTS_PER_BLOCK)->slots[(index %
+																																QF_SLOTS_PER_BLOCK)
 																			 * qf->metadata->bits_per_slot / 8];
 	uint64_t t = *p;
 	uint64_t mask = BITMASK(qf->metadata->bits_per_slot);
 	uint64_t v = value;
-	int shift = ((index % SLOTS_PER_BLOCK) * qf->metadata->bits_per_slot) % 8;
+	int shift = ((index % QF_SLOTS_PER_BLOCK) * qf->metadata->bits_per_slot) % 8;
 	mask <<= shift;
 	v <<= shift;
 	t &= ~mask;
@@ -573,14 +573,14 @@ static inline uint64_t block_offset(const QF *qf, uint64_t blockidx)
 			get_block(qf, blockidx)->offset < BITMASK(8*sizeof(qf->blocks[0].offset)))
 		return get_block(qf, blockidx)->offset;
 
-	return run_end(qf, SLOTS_PER_BLOCK * blockidx - 1) - SLOTS_PER_BLOCK *
+	return run_end(qf, QF_SLOTS_PER_BLOCK * blockidx - 1) - QF_SLOTS_PER_BLOCK *
 		blockidx + 1;
 }
 
 static inline uint64_t run_end(const QF *qf, uint64_t hash_bucket_index)
 {
-	uint64_t bucket_block_index       = hash_bucket_index / SLOTS_PER_BLOCK;
-	uint64_t bucket_intrablock_offset = hash_bucket_index % SLOTS_PER_BLOCK;
+	uint64_t bucket_block_index       = hash_bucket_index / QF_SLOTS_PER_BLOCK;
+	uint64_t bucket_intrablock_offset = hash_bucket_index % QF_SLOTS_PER_BLOCK;
 	uint64_t bucket_blocks_offset = block_offset(qf, bucket_block_index);
 
 	uint64_t bucket_intrablock_rank   = bitrank(get_block(qf,
@@ -591,17 +591,17 @@ static inline uint64_t run_end(const QF *qf, uint64_t hash_bucket_index)
 		if (bucket_blocks_offset <= bucket_intrablock_offset)
 			return hash_bucket_index;
 		else
-			return SLOTS_PER_BLOCK * bucket_block_index + bucket_blocks_offset - 1;
+			return QF_SLOTS_PER_BLOCK * bucket_block_index + bucket_blocks_offset - 1;
 	}
 
 	uint64_t runend_block_index  = bucket_block_index + bucket_blocks_offset /
-		SLOTS_PER_BLOCK;
-	uint64_t runend_ignore_bits  = bucket_blocks_offset % SLOTS_PER_BLOCK;
+		QF_SLOTS_PER_BLOCK;
+	uint64_t runend_ignore_bits  = bucket_blocks_offset % QF_SLOTS_PER_BLOCK;
 	uint64_t runend_rank         = bucket_intrablock_rank - 1;
 	uint64_t runend_block_offset = bitselectv(get_block(qf,
 																						runend_block_index)->runends[0],
 																						runend_ignore_bits, runend_rank);
-	if (runend_block_offset == SLOTS_PER_BLOCK) {
+	if (runend_block_offset == QF_SLOTS_PER_BLOCK) {
 		if (bucket_blocks_offset == 0 && bucket_intrablock_rank == 0) {
 			/* The block begins in empty space, and this bucket is in that region of
 			 * empty space */
@@ -616,11 +616,11 @@ static inline uint64_t run_end(const QF *qf, uint64_t hash_bucket_index)
 				runend_block_offset = bitselectv(get_block(qf,
 																									 runend_block_index)->runends[0],
 																				 runend_ignore_bits, runend_rank);
-			} while (runend_block_offset == SLOTS_PER_BLOCK);
+			} while (runend_block_offset == QF_SLOTS_PER_BLOCK);
 		}
 	}
 
-	uint64_t runend_index = SLOTS_PER_BLOCK * runend_block_index +
+	uint64_t runend_index = QF_SLOTS_PER_BLOCK * runend_block_index +
 		runend_block_offset;
 	if (runend_index < hash_bucket_index)
 		return hash_bucket_index;
@@ -630,11 +630,11 @@ static inline uint64_t run_end(const QF *qf, uint64_t hash_bucket_index)
 
 static inline int offset_lower_bound(const QF *qf, uint64_t slot_index)
 {
-	const qfblock * b = get_block(qf, slot_index / SLOTS_PER_BLOCK);
-	const uint64_t slot_offset = slot_index % SLOTS_PER_BLOCK;
+	const qfblock * b = get_block(qf, slot_index / QF_SLOTS_PER_BLOCK);
+	const uint64_t slot_offset = slot_index % QF_SLOTS_PER_BLOCK;
 	const uint64_t boffset = b->offset;
 	const uint64_t occupieds = b->occupieds[0] & BITMASK(slot_offset+1);
-	assert(SLOTS_PER_BLOCK == 64);
+	assert(QF_SLOTS_PER_BLOCK == 64);
 	if (boffset <= slot_offset) {
 		const uint64_t runends = (b->runends[0] & BITMASK(slot_offset)) >> boffset;
 		return popcnt(occupieds) - popcnt(runends);
@@ -683,15 +683,15 @@ static inline uint64_t shift_into_b(const uint64_t a, const uint64_t b,
 	return a_component | b_shifted | (b & b_mask);
 }
 
-#if BITS_PER_SLOT == 8 || BITS_PER_SLOT == 16 || BITS_PER_SLOT == 32 || BITS_PER_SLOT == 64
+#if QF_BITS_PER_SLOT == 8 || QF_BITS_PER_SLOT == 16 || QF_BITS_PER_SLOT == 32 || QF_BITS_PER_SLOT == 64
 
 static inline void shift_remainders(QF *qf, uint64_t start_index, uint64_t
 																		empty_index)
 {
-	uint64_t start_block  = start_index / SLOTS_PER_BLOCK;
-	uint64_t start_offset = start_index % SLOTS_PER_BLOCK;
-	uint64_t empty_block  = empty_index / SLOTS_PER_BLOCK;
-	uint64_t empty_offset = empty_index % SLOTS_PER_BLOCK;
+	uint64_t start_block  = start_index / QF_SLOTS_PER_BLOCK;
+	uint64_t start_offset = start_index % QF_SLOTS_PER_BLOCK;
+	uint64_t empty_block  = empty_index / QF_SLOTS_PER_BLOCK;
+	uint64_t empty_offset = empty_index % QF_SLOTS_PER_BLOCK;
 
 	assert (start_index <= empty_index && empty_index < qf->metadata->xnslots);
 
@@ -700,9 +700,9 @@ static inline void shift_remainders(QF *qf, uint64_t start_index, uint64_t
 						&get_block(qf, empty_block)->slots[0],
 						empty_offset * sizeof(qf->blocks[0].slots[0]));
 		get_block(qf, empty_block)->slots[0] = get_block(qf,
-																			empty_block-1)->slots[SLOTS_PER_BLOCK-1];
+																			empty_block-1)->slots[QF_SLOTS_PER_BLOCK-1];
 		empty_block--;
-		empty_offset = SLOTS_PER_BLOCK-1;
+		empty_offset = QF_SLOTS_PER_BLOCK-1;
 	}
 
 	memmove(&get_block(qf, empty_block)->slots[start_offset+1], 
@@ -744,26 +744,26 @@ static inline void qf_dump_block(const QF *qf, uint64_t i)
 	printf("%-192d", get_block(qf, i)->offset);
 	printf("\n");
 
-	for (j = 0; j < SLOTS_PER_BLOCK; j++)
+	for (j = 0; j < QF_SLOTS_PER_BLOCK; j++)
 		printf("%02lx ", j);
 	printf("\n");
 
-	for (j = 0; j < SLOTS_PER_BLOCK; j++)
+	for (j = 0; j < QF_SLOTS_PER_BLOCK; j++)
 		printf(" %d ", (get_block(qf, i)->occupieds[j/64] & (1ULL << (j%64))) ? 1 : 0);
 	printf("\n");
 
-	for (j = 0; j < SLOTS_PER_BLOCK; j++)
+	for (j = 0; j < QF_SLOTS_PER_BLOCK; j++)
 		printf(" %d ", (get_block(qf, i)->runends[j/64] & (1ULL << (j%64))) ? 1 : 0);
 	printf("\n");
 
-#if BITS_PER_SLOT == 8 || BITS_PER_SLOT == 16 || BITS_PER_SLOT == 32
-	for (j = 0; j < SLOTS_PER_BLOCK; j++)
+#if QF_BITS_PER_SLOT == 8 || QF_BITS_PER_SLOT == 16 || QF_BITS_PER_SLOT == 32
+	for (j = 0; j < QF_SLOTS_PER_BLOCK; j++)
 		printf("%02x ", get_block(qf, i)->slots[j]);
-#elif BITS_PER_SLOT == 64
-	for (j = 0; j < SLOTS_PER_BLOCK; j++)
+#elif QF_BITS_PER_SLOT == 64
+	for (j = 0; j < QF_SLOTS_PER_BLOCK; j++)
 		printf("%02lx ", get_block(qf, i)->slots[j]);
 #else
-	for (j = 0; j < SLOTS_PER_BLOCK * qf->metadata->bits_per_slot / 8; j++)
+	for (j = 0; j < QF_SLOTS_PER_BLOCK * qf->metadata->bits_per_slot / 8; j++)
 		printf("%02x ", get_block(qf, i)->slots[j]);
 #endif
 
@@ -880,7 +880,7 @@ static inline void insert_replace_slots_and_shift_remainders_and_runends_and_off
 			METADATA_WORD(qf, runends, overwrite_index + i) &= ~(1ULL <<
 																													 (((overwrite_index
 																															+ i) %
-																														 SLOTS_PER_BLOCK)
+																														 QF_SLOTS_PER_BLOCK)
 																														% 64));
 
 		switch (operation) {
@@ -888,20 +888,20 @@ static inline void insert_replace_slots_and_shift_remainders_and_runends_and_off
 				assert (noverwrites == 0);
 				METADATA_WORD(qf, runends, overwrite_index + total_remainders - 1) |=
 					1ULL << (((overwrite_index + total_remainders - 1) %
-										SLOTS_PER_BLOCK) % 64);
+										QF_SLOTS_PER_BLOCK) % 64);
 				break;
 			case 1: /* append to bucket */
 				METADATA_WORD(qf, runends, overwrite_index + noverwrites - 1)      &=
-					~(1ULL << (((overwrite_index + noverwrites - 1) % SLOTS_PER_BLOCK) %
+					~(1ULL << (((overwrite_index + noverwrites - 1) % QF_SLOTS_PER_BLOCK) %
 										 64));
 				METADATA_WORD(qf, runends, overwrite_index + total_remainders - 1) |=
 					1ULL << (((overwrite_index + total_remainders - 1) %
-										SLOTS_PER_BLOCK) % 64);
+										QF_SLOTS_PER_BLOCK) % 64);
 				break;
 			case 2: /* insert into bucket */
 				METADATA_WORD(qf, runends, overwrite_index + total_remainders - 1) &=
 					~(1ULL << (((overwrite_index + total_remainders - 1) %
-											SLOTS_PER_BLOCK) % 64));
+											QF_SLOTS_PER_BLOCK) % 64));
 				break;
 			default:
 				fprintf(stderr, "Invalid operation %d\n", operation);
@@ -909,9 +909,9 @@ static inline void insert_replace_slots_and_shift_remainders_and_runends_and_off
 		}
 
 		uint64_t npreceding_empties = 0;
-		for (i = bucket_index / SLOTS_PER_BLOCK + 1; i <= empties[0]/SLOTS_PER_BLOCK; i++) {
+		for (i = bucket_index / QF_SLOTS_PER_BLOCK + 1; i <= empties[0]/QF_SLOTS_PER_BLOCK; i++) {
 			while ((int64_t)npreceding_empties < ninserts &&
-						 empties[ninserts - 1 - npreceding_empties]  / SLOTS_PER_BLOCK < i)
+						 empties[ninserts - 1 - npreceding_empties]  / QF_SLOTS_PER_BLOCK < i)
 				npreceding_empties++;
 			
 			if (get_block(qf, i)->offset + ninserts - npreceding_empties < BITMASK(8*sizeof(qf->blocks[0].offset)))
@@ -999,7 +999,7 @@ static inline void remove_replace_slots_and_shift_remainders_and_runends_and_off
 	// Then find the runend slot corresponding to the last run in the
 	// original_bucket block.
 	// Update the offset of the block to which it belongs.
-	uint64_t original_block = original_bucket / SLOTS_PER_BLOCK;
+	uint64_t original_block = original_bucket / QF_SLOTS_PER_BLOCK;
 	while (1 && old_length > total_remainders) {	// we only update offsets if we shift/delete anything
 		int32_t last_occupieds_bit = bitscanreverse(get_block(qf, original_block)->occupieds[0]);
 		// there is nothing in the block
@@ -1008,25 +1008,25 @@ static inline void remove_replace_slots_and_shift_remainders_and_runends_and_off
 				break;
 			get_block(qf, original_block + 1)->offset = 0;
 		} else {
-			uint64_t last_occupieds_hash_index = SLOTS_PER_BLOCK * original_block + last_occupieds_bit;
+			uint64_t last_occupieds_hash_index = QF_SLOTS_PER_BLOCK * original_block + last_occupieds_bit;
 			uint64_t runend_index = run_end(qf, last_occupieds_hash_index);
 			// runend spans across the block
 			// update the offset of the next block
-			if (runend_index / SLOTS_PER_BLOCK == original_block) { // if the run ends in the same block
+			if (runend_index / QF_SLOTS_PER_BLOCK == original_block) { // if the run ends in the same block
 				if (get_block(qf, original_block + 1)->offset == 0)
 					break;
 				get_block(qf, original_block + 1)->offset = 0;
-			} else if (runend_index / SLOTS_PER_BLOCK == original_block + 1) { // if the last run spans across one block
-				if (get_block(qf, original_block + 1)->offset == (runend_index % SLOTS_PER_BLOCK) + 1)
+			} else if (runend_index / QF_SLOTS_PER_BLOCK == original_block + 1) { // if the last run spans across one block
+				if (get_block(qf, original_block + 1)->offset == (runend_index % QF_SLOTS_PER_BLOCK) + 1)
 					break;
-				get_block(qf, original_block + 1)->offset = (runend_index % SLOTS_PER_BLOCK) + 1;
+				get_block(qf, original_block + 1)->offset = (runend_index % QF_SLOTS_PER_BLOCK) + 1;
 			} else { // if the last run spans across multiple blocks
 				uint64_t i;
-				for (i = original_block + 1; i < runend_index / SLOTS_PER_BLOCK - 1; i++)
-					get_block(qf, i)->offset = SLOTS_PER_BLOCK;
-				if (get_block(qf, runend_index / SLOTS_PER_BLOCK)->offset == (runend_index % SLOTS_PER_BLOCK) + 1)
+				for (i = original_block + 1; i < runend_index / QF_SLOTS_PER_BLOCK - 1; i++)
+					get_block(qf, i)->offset = QF_SLOTS_PER_BLOCK;
+				if (get_block(qf, runend_index / QF_SLOTS_PER_BLOCK)->offset == (runend_index % QF_SLOTS_PER_BLOCK) + 1)
 					break;
-				get_block(qf, runend_index / SLOTS_PER_BLOCK)->offset = (runend_index % SLOTS_PER_BLOCK) + 1;
+				get_block(qf, runend_index / QF_SLOTS_PER_BLOCK)->offset = (runend_index % QF_SLOTS_PER_BLOCK) + 1;
 			}
 		}
 		original_block++;
@@ -1204,7 +1204,7 @@ static inline bool insert1(QF *qf, __uint128_t hash)
 {
 	uint64_t hash_remainder           = hash & BITMASK(qf->metadata->bits_per_slot);
 	uint64_t hash_bucket_index        = hash >> qf->metadata->bits_per_slot;
-	uint64_t hash_bucket_block_offset = hash_bucket_index % SLOTS_PER_BLOCK;
+	uint64_t hash_bucket_block_offset = hash_bucket_index % QF_SLOTS_PER_BLOCK;
 
 	if (qf->runtimedata->lock_mode != LOCKS_FORBIDDEN) {
 		if (!qf_lock(qf, hash_bucket_index, /*small*/ true))
@@ -1396,23 +1396,23 @@ static inline bool insert1(QF *qf, __uint128_t hash)
 				case 0:
 					METADATA_WORD(qf, runends, insert_index)   |= 1ULL << ((insert_index
 																																	%
-																																	SLOTS_PER_BLOCK)
+																																	QF_SLOTS_PER_BLOCK)
 																																 % 64);
 					break;
 				case 1:
 					METADATA_WORD(qf, runends, insert_index-1) &= ~(1ULL <<
 																													(((insert_index-1) %
-																														SLOTS_PER_BLOCK) %
+																														QF_SLOTS_PER_BLOCK) %
 																													 64));
 					METADATA_WORD(qf, runends, insert_index)   |= 1ULL << ((insert_index
 																																	%
-																																	SLOTS_PER_BLOCK)
+																																	QF_SLOTS_PER_BLOCK)
 																																 % 64);
 					break;
 				case 2:
 					METADATA_WORD(qf, runends, insert_index)   &= ~(1ULL <<
 																													((insert_index %
-																														SLOTS_PER_BLOCK) %
+																														QF_SLOTS_PER_BLOCK) %
 																													 64));
 					break;
 				default:
@@ -1424,8 +1424,8 @@ static inline bool insert1(QF *qf, __uint128_t hash)
 			 * and block of the empty slot  
 			 * */
 			uint64_t i;
-			for (i = hash_bucket_index / SLOTS_PER_BLOCK + 1; i <=
-					 empty_slot_index/SLOTS_PER_BLOCK; i++) {
+			for (i = hash_bucket_index / QF_SLOTS_PER_BLOCK + 1; i <=
+					 empty_slot_index/QF_SLOTS_PER_BLOCK; i++) {
 				if (get_block(qf, i)->offset < BITMASK(8*sizeof(qf->blocks[0].offset)))
 					get_block(qf, i)->offset++;
 				assert(get_block(qf, i)->offset != 0);
@@ -1449,7 +1449,7 @@ static inline bool insert(QF *qf, __uint128_t hash, uint64_t count, enum
 {
 	uint64_t hash_remainder           = hash & BITMASK(qf->metadata->bits_per_slot);
 	uint64_t hash_bucket_index        = hash >> qf->metadata->bits_per_slot;
-	uint64_t hash_bucket_block_offset = hash_bucket_index % SLOTS_PER_BLOCK;
+	uint64_t hash_bucket_block_offset = hash_bucket_index % QF_SLOTS_PER_BLOCK;
 	/*uint64_t hash_bucket_lock_offset  = hash_bucket_index % NUM_SLOTS_TO_LOCK;*/
 
 	if (flag != LOCKS_FORBIDDEN) {
@@ -1624,7 +1624,7 @@ uint64_t qf_init(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t value_bits
 	assert(popcnt(nslots) == 1); /* nslots must be a power of 2 */
 	num_slots = nslots;
 	xnslots = nslots + 10*sqrt((double)nslots);
-	nblocks = (xnslots + SLOTS_PER_BLOCK - 1) / SLOTS_PER_BLOCK;
+	nblocks = (xnslots + QF_SLOTS_PER_BLOCK - 1) / QF_SLOTS_PER_BLOCK;
 	key_remainder_bits = key_bits;
 	while (nslots > 1) {
 		assert(key_remainder_bits > 0);
@@ -1633,12 +1633,12 @@ uint64_t qf_init(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t value_bits
 	}
 
 	bits_per_slot = key_remainder_bits + value_bits;
-	assert (BITS_PER_SLOT == 0 || BITS_PER_SLOT == qf->metadata->bits_per_slot);
+	assert (QF_BITS_PER_SLOT == 0 || QF_BITS_PER_SLOT == qf->metadata->bits_per_slot);
 	assert(bits_per_slot > 1);
-#if BITS_PER_SLOT == 8 || BITS_PER_SLOT == 16 || BITS_PER_SLOT == 32 || BITS_PER_SLOT == 64
+#if QF_BITS_PER_SLOT == 8 || QF_BITS_PER_SLOT == 16 || QF_BITS_PER_SLOT == 32 || QF_BITS_PER_SLOT == 64
 	size = nblocks * sizeof(qfblock);
 #else
-	size = nblocks * (sizeof(qfblock) + SLOTS_PER_BLOCK * bits_per_slot / 8);
+	size = nblocks * (sizeof(qfblock) + QF_SLOTS_PER_BLOCK * bits_per_slot / 8);
 #endif
 
 	total_num_bytes = sizeof(qfmetadata) + size;
@@ -1662,8 +1662,8 @@ uint64_t qf_init(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t value_bits
 
 	qf->metadata->range = qf->metadata->nslots;
 	qf->metadata->range <<= qf->metadata->key_remainder_bits;
-	qf->metadata->nblocks = (qf->metadata->xnslots + SLOTS_PER_BLOCK - 1) /
-		SLOTS_PER_BLOCK;
+	qf->metadata->nblocks = (qf->metadata->xnslots + QF_SLOTS_PER_BLOCK - 1) /
+		QF_SLOTS_PER_BLOCK;
 	qf->metadata->nelts = 0;
 	qf->metadata->ndistinct_elts = 0;
 	qf->metadata->noccupied_slots = 0;
@@ -1778,10 +1778,10 @@ void qf_reset(QF *qf)
 	memset(qf->wait_times, 0,
 				 (qf->runtimedata->num_locks+1)*sizeof(wait_time_data));
 #endif
-#if BITS_PER_SLOT == 8 || BITS_PER_SLOT == 16 || BITS_PER_SLOT == 32 || BITS_PER_SLOT == 64
+#if QF_BITS_PER_SLOT == 8 || QF_BITS_PER_SLOT == 16 || QF_BITS_PER_SLOT == 32 || QF_BITS_PER_SLOT == 64
 	memset(qf->blocks, 0, qf->metadata->nblocks* sizeof(qfblock));
 #else
-	memset(qf->blocks, 0, qf->metadata->nblocks*(sizeof(qfblock) + SLOTS_PER_BLOCK *
+	memset(qf->blocks, 0, qf->metadata->nblocks*(sizeof(qfblock) + QF_SLOTS_PER_BLOCK *
 																		 qf->metadata->bits_per_slot / 8));
 #endif
 }
@@ -2032,7 +2032,7 @@ bool qf_iterator(const QF *qf, QFi *qfi, uint64_t position)
 				idx = bitselect(get_block(qf, block_index)->occupieds[0], 0);
 			}
 		}
-		position = block_index * SLOTS_PER_BLOCK + idx;
+		position = block_index * QF_SLOTS_PER_BLOCK + idx;
 	}
 
 	qfi->qf = qf;
@@ -2105,7 +2105,7 @@ bool qf_iterator_hash(const QF *qf, QFi *qfi, uint64_t hash)
 	if (!is_occupied(qf, hash_bucket_index) || !flag) {
 		uint64_t position = hash_bucket_index;
 		assert(position < qf->metadata->nslots);
-		uint64_t block_index = position / SLOTS_PER_BLOCK;
+		uint64_t block_index = position / QF_SLOTS_PER_BLOCK;
 		uint64_t idx = bitselect(get_block(qf, block_index)->occupieds[0], 0);
 		if (idx == 64) {
 			while(idx == 64 && block_index < qf->metadata->nblocks) {
@@ -2113,7 +2113,7 @@ bool qf_iterator_hash(const QF *qf, QFi *qfi, uint64_t hash)
 				idx = bitselect(get_block(qf, block_index)->occupieds[0], 0);
 			}
 		}
-		position = block_index * SLOTS_PER_BLOCK + idx;
+		position = block_index * QF_SLOTS_PER_BLOCK + idx;
 		qfi->run = position;
 		qfi->current = position == 0 ? 0 : run_end(qfi->qf, position-1) + 1;
 		if (qfi->current < position)
@@ -2167,9 +2167,9 @@ int qfi_next(QFi *qfi)
 			/* save to check if the new current is the new cluster. */
 			uint64_t old_current = qfi->current;
 #endif
-			uint64_t block_index = qfi->run / SLOTS_PER_BLOCK;
+			uint64_t block_index = qfi->run / QF_SLOTS_PER_BLOCK;
 			uint64_t rank = bitrank(get_block(qfi->qf, block_index)->occupieds[0],
-															qfi->run % SLOTS_PER_BLOCK);
+															qfi->run % QF_SLOTS_PER_BLOCK);
 			uint64_t next_run = bitselect(get_block(qfi->qf,
 																							block_index)->occupieds[0],
 																		rank);
@@ -2186,7 +2186,7 @@ int qfi_next(QFi *qfi)
 				qfi->run = qfi->current = qfi->qf->metadata->xnslots;
 				return 1;
 			}
-			qfi->run = block_index * SLOTS_PER_BLOCK + next_run;
+			qfi->run = block_index * QF_SLOTS_PER_BLOCK + next_run;
 			qfi->current++;
 			if (qfi->current < qfi->run)
 				qfi->current = qfi->run;

--- a/src/gqf.c
+++ b/src/gqf.c
@@ -41,6 +41,18 @@
  * the content of the slots.
  ******************************************************************/
 
+#define MAX_VALUE(nbits) ((1ULL << (nbits)) - 1)
+#define BITMASK(nbits)                                            \
+  ((nbits) == 64 ? 0xffffffffffffffff : MAX_VALUE(nbits))
+#define NUM_SLOTS_TO_LOCK (1ULL<<16)
+#define CLUSTER_SIZE (1ULL<<14)
+#define METADATA_WORD(qf,field,slot_index)                              \
+  (get_block((qf), (slot_index) /                                       \
+             SLOTS_PER_BLOCK)->field[((slot_index)  % SLOTS_PER_BLOCK) / 64])
+
+
+#define BILLION 1000000000L
+
 #ifdef DEBUG
 #define PRINT_DEBUG 1
 #else
@@ -49,6 +61,9 @@
 
 #define DEBUG_CQF(fmt, ...) \
 	do { if (PRINT_DEBUG) fprintf(stderr, fmt, __VA_ARGS__); } while (0)
+
+#define DEBUG_DUMP(qf) \
+	do { if (PRINT_DEBUG) qf_dump_metadata(qf); } while (0)
 
 static __inline__ unsigned long long rdtsc(void)
 {

--- a/src/gqf_file.c
+++ b/src/gqf_file.c
@@ -40,7 +40,7 @@
 #define NUM_SLOTS_TO_LOCK (1ULL<<16)
 
 bool qf_initfile(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t
-								 value_bits, enum lockingmode lock, enum hashmode hash,
+								 value_bits, enum qf_lockingmode lock, enum qf_hashmode hash,
 								 uint32_t seed, char* filename)
 {
 	uint64_t total_num_bytes = qf_init(qf, nslots, key_bits, value_bits,
@@ -83,7 +83,7 @@ bool qf_initfile(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t
 		return false;
 }
 
-uint64_t qf_usefile(QF* qf, enum lockingmode lock, const char* filename)
+uint64_t qf_usefile(QF* qf, enum qf_lockingmode lock, const char* filename)
 {
 	struct stat sb;
 	int ret;
@@ -167,7 +167,7 @@ uint64_t qf_serialize(const QF *qf, const char *filename)
 	return sizeof(qfmetadata) + qf->metadata->total_size_in_bytes;
 }
 
-uint64_t qf_deserialize(QF *qf, enum lockingmode lock, const char *filename)
+uint64_t qf_deserialize(QF *qf, enum qf_lockingmode lock, const char *filename)
 {
 	FILE *fin;
 	fin = fopen(filename, "rb");

--- a/src/gqf_file.c
+++ b/src/gqf_file.c
@@ -35,6 +35,7 @@
 #include "gqf.h"
 #include "gqf_file.h"
 
+#define NUM_SLOTS_TO_LOCK (1ULL<<16)
 
 bool qf_initfile(QF *qf, uint64_t nslots, uint64_t key_bits, uint64_t
 								 value_bits, enum lockingmode lock, enum hashmode hash,

--- a/src/gqf_file.c
+++ b/src/gqf_file.c
@@ -32,7 +32,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include "hashutil.h"
 #include "gqf.h"
+#include "gqf_int.h"
 #include "gqf_file.h"
 
 #define NUM_SLOTS_TO_LOCK (1ULL<<16)


### PR DESCRIPTION
This PR reorganizes the source code to allow much better usages of gqf as a library. In particular is hides all the implementation details into private headers and ensures that everything that is exposed as a part of API will not conflict with anything else.